### PR TITLE
Add PHP lint

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,20 @@
+name: PHP Lint
+
+on:
+  push:
+    paths:
+      - '**/*.php'
+      - '.github/workflows/php-lint.yml'
+  pull_request:
+    paths:
+      - '**/*.php'
+      - '.github/workflows/php-lint.yml'
+
+jobs:
+  phplint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run php -l on all files
+        run: |
+          find . -name '*.php' -print0 | xargs -0 -n 1 php -l

--- a/MicrofyClass.php
+++ b/MicrofyClass.php
@@ -107,6 +107,7 @@ class Microfy
             return new PDO($dsn, $user, $pass, $options);
         } catch (PDOException $e) {
             self::dd("PDO Connection failed: " . $e->getMessage());
+            return null; 
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ Microfy::c('Step A');
 ```
 
 More [Examples](https://itnb.com/MicrofyClass/)
+## ✅ Lint Check
+
+Run PHP's built-in linter across all project files:
+
+```bash
+./scripts/lint.sh
+```
+
 
 ---
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lint all PHP files in the repository
+find . -name '*.php' -print0 | xargs -0 -n 1 php -l


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint PHP files
- add simple bash script for local linting
- document lint check in README

## Testing
- `./scripts/lint.sh` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cc056aa8832499f98da0357d80ad